### PR TITLE
fix: Limit TSDoc to TypeScript files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,3 @@
-/* eslint-disable-next-line tsdoc/syntax */
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
   extends: ['./index.js'],

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable-next-line tsdoc/syntax */
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
   extends: [

--- a/index.js
+++ b/index.js
@@ -14,7 +14,13 @@ module.exports = {
       },
     },
     {
-      files: ['**/*.test.ts'],
+      files: ['**/*.ts', '**/*.tsx'],
+      rules: {
+        'tsdoc/syntax': 'error',
+      },
+    },
+    {
+      files: ['**/*.test.ts', '**/*.test.tsx'],
       rules: {
         // Allow `any` in tests
         '@typescript-eslint/no-unsafe-assignment': 'off',
@@ -69,8 +75,6 @@ module.exports = {
     'jest/prefer-to-have-length': 'error',
     'jest/prefer-todo': 'error',
     'jest/valid-title': 'error',
-
-    'tsdoc/syntax': 'error',
 
     'no-use-before-define': 'off',
     'sort-imports': [


### PR DESCRIPTION
It seems unlikely that JavaScript files would be intentionally documented with TSDoc. Often JSDoc will be used for extended features like an `@types` tag to load in TypeScript definitions.