### PR TITLE
feat: Enable @typescript-eslint/consistent-type-exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ module.exports = {
   plugins: ['eslint-plugin-tsdoc'],
   rules: {
     '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/consistent-type-exports': 'error',
 
     'import/no-duplicates': 'error',
     'import/order': [


### PR DESCRIPTION
Allows auto resolution of these errors which can occur since we enabled isolatedModules:

`error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.`