### PR TITLE
fix: Limit TypeScript parsing to JS/TS files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,21 @@
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
-  extends: [
-    'seek',
-    'plugin:@typescript-eslint/recommended-requiring-type-checking',
-  ],
+  extends: ['seek'],
   ignorePatterns: ['**/.eslintrc.js'],
   overrides: [
+    {
+      extends: [
+        'plugin:@typescript-eslint/recommended-requiring-type-checking',
+      ],
+      files: ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx'],
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+      rules: {
+        '@typescript-eslint/consistent-type-exports': 'error',
+        '@typescript-eslint/no-floating-promises': 'error',
+      },
+    },
     {
       files: ['**/*.js', '**/*.jsx'],
       rules: {
@@ -17,6 +27,7 @@ module.exports = {
     },
     {
       files: ['**/*.ts', '**/*.tsx'],
+      plugins: ['eslint-plugin-tsdoc'],
       rules: {
         'tsdoc/syntax': 'error',
       },
@@ -47,14 +58,7 @@ module.exports = {
       },
     },
   ],
-  parserOptions: {
-    project: './tsconfig.json',
-  },
-  plugins: ['eslint-plugin-tsdoc'],
   rules: {
-    '@typescript-eslint/no-floating-promises': 'error',
-    '@typescript-eslint/consistent-type-exports': 'error',
-
     'import/no-duplicates': 'error',
     'import/order': [
       'error',


### PR DESCRIPTION
This makes it easier for us (or consuming projects) to extend the ESLint configuration for other file types (e.g. https://github.com/ota-meshi/eslint-plugin-yml).

Otherwise, you run into issues like this:

```
Oops! Something went wrong! :(

ESLint: 8.12.0

Error: Error while loading rule '@typescript-eslint/no-floating-promises': You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.
Occurred while linting /my/favourite/filetype.yaml
```