### PR TITLE
feat: Support more JS & TS extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
+const jsExtensions = ['js', 'cjs', 'mjs', 'jsx'];
+const tsExtensions = ['ts', 'cts', 'mts', 'tsx'];
+const allExtensions = [...jsExtensions, ...tsExtensions];
+
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
   extends: ['seek'],
@@ -5,17 +9,15 @@ module.exports = {
     '**/.eslintrc.js',
 
     // Gantry resource files support non-standard syntax (Go templating)
-    '/.gantry/**/*.yaml',
-    '/.gantry/**/*.yml',
-    'gantry*.yaml',
-    'gantry*.yml',
+    '/.gantry/**/*.{yaml,yml}',
+    'gantry*.{yaml,yml}',
   ],
   overrides: [
     {
       extends: [
         'plugin:@typescript-eslint/recommended-requiring-type-checking',
       ],
-      files: ['*.js', '*.jsx', '*.ts', '*.tsx'],
+      files: [`*.{${allExtensions.join(',')}}`],
       parserOptions: {
         project: './tsconfig.json',
       },
@@ -25,7 +27,7 @@ module.exports = {
       },
     },
     {
-      files: ['*.js', '*.jsx'],
+      files: [`*.{${jsExtensions.join(',')}}`],
       rules: {
         '@typescript-eslint/no-unsafe-argument': 'off',
         '@typescript-eslint/no-unsafe-assignment': 'off',
@@ -34,7 +36,7 @@ module.exports = {
       },
     },
     {
-      files: ['*.ts', '*.tsx'],
+      files: [`*.{${tsExtensions.join(',')}}`],
       plugins: ['eslint-plugin-tsdoc'],
       rules: {
         'tsdoc/syntax': 'error',
@@ -42,10 +44,8 @@ module.exports = {
     },
     {
       files: [
-        '*.test.ts',
-        '*.test.tsx',
-        '**/testing/**/*.ts',
-        '**/testing/**/*.tsx',
+        `*.test.{${tsExtensions.join(',')}}`,
+        `**/testing/**/*.{${tsExtensions.join(',')}}`,
       ],
       rules: {
         // Allow `any` in tests
@@ -67,7 +67,7 @@ module.exports = {
     },
     {
       extends: ['plugin:yml/prettier'],
-      files: ['*.yaml', '*.yml'],
+      files: ['*.{yaml,yml}'],
     },
   ],
   rules: {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@types/eslint": "^8.4.1",
-    "@typescript-eslint/eslint-plugin": "^5.45.0",
-    "@typescript-eslint/parser": "^5.45.0",
+    "@typescript-eslint/eslint-plugin": "^5.55.0",
+    "@typescript-eslint/parser": "^5.55.0",
     "eslint-config-seek": "^10.2.0",
     "eslint-plugin-jest": "^27.0.0",
     "eslint-plugin-tsdoc": "^0.2.14",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/eslint": "^8.4.1",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
-    "eslint-config-seek": "^10.0.0",
+    "eslint-config-seek": "^10.2.0",
     "eslint-plugin-jest": "^27.0.0",
     "eslint-plugin-tsdoc": "^0.2.14",
     "eslint-plugin-yml": "^1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2770,7 +2770,7 @@ eslint-config-prettier@^8.6.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz#dec1d29ab728f4fa63061774e1672ac4e363d207"
   integrity sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==
 
-eslint-config-seek@^10.0.0:
+eslint-config-seek@^10.0.0, eslint-config-seek@^10.2.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/eslint-config-seek/-/eslint-config-seek-10.2.0.tgz#701ffb2559da96691c5d499bc3602f02b85e7b12"
   integrity sha512-lxO29+e8wZpATZ29ESH+rxiLFQFOOx2BcZJaSrAaSc4IFEtwE7q7Gbep+9M3lLIGHsGVKRzKLYkj9aFWfZv5JA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,7 +1489,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^5.45.0", "@typescript-eslint/eslint-plugin@^5.53.0":
+"@typescript-eslint/eslint-plugin@^5.45.0", "@typescript-eslint/eslint-plugin@^5.53.0", "@typescript-eslint/eslint-plugin@^5.55.0":
   version "5.55.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.55.0.tgz#bc2400c3a23305e8c9a9c04aa40933868aaaeb47"
   integrity sha512-IZGc50rtbjk+xp5YQoJvmMPmJEYoC53SiKPXyqWfv15XoD2Y5Kju6zN0DwlmaGJp1Iw33JsWJcQ7nw0lGCGjVg==
@@ -1505,7 +1505,7 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.45.0", "@typescript-eslint/parser@^5.53.0":
+"@typescript-eslint/parser@^5.45.0", "@typescript-eslint/parser@^5.53.0", "@typescript-eslint/parser@^5.55.0":
   version "5.55.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.55.0.tgz#8c96a0b6529708ace1dcfa60f5e6aec0f5ed2262"
   integrity sha512-ppvmeF7hvdhUUZWSd2EEWfzcFkjJzgNQzVST22nzg958CR+sphy8A6K7LXQZd6V75m1VKjp+J4g/PCEfSCmzhw==


### PR DESCRIPTION
Per seek-oss/eslint-config-seek#90.

Ironically `@typescript-eslint/restrict-template-expressions` is unhappy with relying on the array default `toString` as described in that PR.