### PR TITLE
fix: Ignore Gantry YAML files

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,10 @@ module.exports = {
     '**/.eslintrc.js',
 
     // Gantry resource files support non-standard syntax (Go templating)
-    '/.gantry/**/*.{yaml,yml}',
-    'gantry*.{yaml,yml}',
+    '**/.gantry/**/*.yaml',
+    '**/.gantry/**/*.yml',
+    '**/gantry*.yaml',
+    '**/gantry*.yml',
   ],
   overrides: [
     {


### PR DESCRIPTION
Brace expansion doesn't seem to work under `ignorePatterns` and the previous patterns did not account for files under a different level of directory nesting.

https://github.com/seek-oss/skuba/actions/runs/4458623077/jobs/7830549515?pr=1126#step:4:288