### PR TITLE
fix: Remove React linting

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const tsExtensions = ['ts', 'cts', 'mts', 'tsx'];
 
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
-  extends: ['seek'],
+  extends: ['seek/base'],
   ignorePatterns: [
     '**/.eslintrc.js',
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/eslint": "^8.4.1",
     "@typescript-eslint/eslint-plugin": "^5.55.0",
     "@typescript-eslint/parser": "^5.55.0",
-    "eslint-config-seek": "^10.2.0",
+    "eslint-config-seek": "^10.3.0",
     "eslint-plugin-jest": "^27.0.0",
     "eslint-plugin-tsdoc": "^0.2.14",
     "eslint-plugin-yml": "^1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2773,10 +2773,10 @@ eslint-config-prettier@^8.6.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz#bfda738d412adc917fd7b038857110efe98c9348"
   integrity sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==
 
-eslint-config-seek@^10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-seek/-/eslint-config-seek-10.2.0.tgz#701ffb2559da96691c5d499bc3602f02b85e7b12"
-  integrity sha512-lxO29+e8wZpATZ29ESH+rxiLFQFOOx2BcZJaSrAaSc4IFEtwE7q7Gbep+9M3lLIGHsGVKRzKLYkj9aFWfZv5JA==
+eslint-config-seek@^10.2.0, eslint-config-seek@^10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-seek/-/eslint-config-seek-10.3.0.tgz#5a4718a4b4635be92a81eae14faded913cb92ab2"
+  integrity sha512-IIgOMNIwtCBLUOuyxMmMDbksZ7cmDCUjscld8Hg1hM5+3fvwbMzQLAWJBmp2FWFMUeReuIzWfMwXJV8GacsGyQ==
   dependencies:
     "@babel/core" "^7.21.0"
     "@babel/eslint-parser" "^7.19.1"


### PR DESCRIPTION
This removes react rules, improving performance marginally and removing the annoying warning:

> Warning: React version was set to "detect" in eslint-plugin-react settings, but the "react" package is not installed. Assuming latest React version for linting.

BREAKING CHANGE: If you use this library for react linting, this will affect you. This library is intended for linting backend applications, and so likely the fix here should be migrate to something else instead (like eslint-config-seek).