### PR TITLE
feat: Disable `Promise<void>` return checks in tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,14 @@ module.exports = {
 
         // Allow e.g. `/** @jest-environment jsdom */` directives
         'tsdoc/syntax': 'off',
+
+        // Allow potential floating promises in tests only for Koa compatibility
+        // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-misused-promises.md#checksvoidreturn
+        // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42551#issuecomment-648816869
+        '@typescript-eslint/no-misused-promises': [
+          'error',
+          { checksVoidReturn: false },
+        ],
       },
     },
     {


### PR DESCRIPTION
This should unblock seek-oss/skuba#1366.

https://github.com/seek-oss/skuba/actions/runs/7387953763/job/20097749462?pr=1366#step:5:453